### PR TITLE
The logging-operator can't run events-reader, it crash after run with the error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ EXPOSE 8080
 
 USER $USER_UID
 
-CMD ["/events-reader/qubership-kube-events-reader"]
+CMD ["/events-reader/eventsreader"]


### PR DESCRIPTION
set correct folder for the container