### PR TITLE
chore(ci): fix golangci-linter issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -18,7 +19,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/strings/slices"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )

--- a/pkg/controller/events_reader_controller.go
+++ b/pkg/controller/events_reader_controller.go
@@ -129,14 +129,14 @@ func NewIndexerInformer(kubeRestClient rest.Interface, namespace string, queue w
 	eventListWatcher := watcherFunc(kubeRestClient, namespace)
 
 	handlers := cache.ResourceEventHandlerFuncs{
-		AddFunc: func(event interface{}) {
+		AddFunc: func(event any) {
 			key, err := cache.MetaNamespaceKeyFunc(event)
 			//todo here can be added some filters to not add to queue
 			if err == nil {
 				queue.AddRateLimited(KeyEvent{Key: key, EventType: watch.Added})
 			}
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			newEvent := newObj.(*corev1.Event)
 			oldEvent := oldObj.(*corev1.Event)
 			if newEvent.ResourceVersion == oldEvent.ResourceVersion {
@@ -173,7 +173,7 @@ func (c *EventController) Run(workers int, stopCh chan struct{}) {
 		return
 	}
 
-	for i := 0; i < workers; i++ {
+	for range workers {
 		go wait.Until(c.runWorker, time.Second, stopCh)
 	}
 
@@ -204,10 +204,10 @@ func (c *EventController) processNextWorkItem() bool {
 	var err error
 	if keyEvent != nilKeyEvent {
 		switch keyEvent.EventType {
-			case watch.Added:
-				slog.Debug("add event is triggered for object", "key", keyEvent.Key)
-			case watch.Modified:
-				slog.Debug("modify event is triggered for object", "key", keyEvent.Key)
+		case watch.Added:
+			slog.Debug("add event is triggered for object", "key", keyEvent.Key)
+		case watch.Modified:
+			slog.Debug("modify event is triggered for object", "key", keyEvent.Key)
 		}
 		err = c.syncHandler(keyEvent.Key)
 	}
@@ -239,7 +239,7 @@ func (c *EventController) syncHandler(key string) error {
 }
 
 // processEvent implements logic of processing event and printing it to stdout
-func (c *EventController) processEvent(obj interface{}) error {
+func (c *EventController) processEvent(obj any) error {
 
 	slog.Debug("process triggered for an object", "object", obj)
 	eventObj, ok := obj.(*corev1.Event)

--- a/pkg/utils/health_test.go
+++ b/pkg/utils/health_test.go
@@ -21,8 +21,7 @@ func TestStartHealthEndpointRejectsInvalidPort(t *testing.T) {
 }
 
 func TestStartHealthEndpointRegistersHandlers(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	l, err := net.Listen("tcp", ":0")
 	if err != nil {


### PR DESCRIPTION
# What does this PR do?

Fix issues found by golangci-linter related to the deprecated slices package:

```bash
../../main.go:118:5: SA1019: slices.Contains is deprecated: use stdlib slices.Contains instead. (staticcheck)
	if slices.Contains(outputs, logsType) {
	   ^
../../main.go:127:5: SA1019: slices.Contains is deprecated: use stdlib slices.Contains instead. (staticcheck)
	if slices.Contains(outputs, metricsType) {
	   ^
2 issues:
* staticcheck: 2
```