### PR TITLE
chore(go): add toolchain directive to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/Netcracker/qubership-kube-events-reader
 
 go 1.26.0
 
+toolchain go1.26.4
+
 require (
 	github.com/go-logr/logr v1.4.3
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
## Summary

- Adds `toolchain go1.26.4` directive to `go.mod` to explicitly pin the Go toolchain version.
- This replaces PR #159 which could not be reopened after the branch was force-pushed to fix an orphan commit.

## Changes

- `go.mod`: added `toolchain go1.26.4` line after the `go 1.26.0` directive.

## Test plan

- [ ] Verify `go.mod` contains `toolchain go1.26.4` after the `go 1.26.0` line.
- [ ] Ensure CI passes with the updated `go.mod`.